### PR TITLE
SLVS-885 S2201 should not report on custom extension method

### DIFF
--- a/src/SonarLint.CSharp/Rules/ReturnValueIgnored.cs
+++ b/src/SonarLint.CSharp/Rules/ReturnValueIgnored.cs
@@ -170,8 +170,8 @@ namespace SonarLint.Rules.CSharp
 
         private static bool IsLinqMethod(IMethodSymbol methodSymbol)
         {
-            return methodSymbol.IsExtensionOn(KnownType.System_Collections_Generic_IEnumerable_T) ||
-                methodSymbol.IsExtensionOn(KnownType.System_Collections_IEnumerable);
+            return methodSymbol.ContainingType.Is(KnownType.System_Linq_Enumerable) ||
+                methodSymbol.ContainingType.Is(KnownType.System_Linq_ImmutableArrayExtensions);
         }
     }
 }

--- a/src/SonarLint/Helpers/KnownType.cs
+++ b/src/SonarLint/Helpers/KnownType.cs
@@ -158,6 +158,9 @@ namespace SonarLint.Helpers
         public static readonly KnownType System_ServiceModel_ServiceContractAttribute = new KnownType("System.ServiceModel.ServiceContractAttribute");
         public static readonly KnownType System_ServiceModel_OperationContractAttribute = new KnownType("System.ServiceModel.OperationContractAttribute");
 
+        public static readonly KnownType System_Linq_Enumerable = new KnownType("System.Linq.Enumerable");
+        public static readonly KnownType System_Linq_ImmutableArrayExtensions = new KnownType("System.Linq.ImmutableArrayExtensions");
+
         #endregion
 
         public string TypeName { get; }

--- a/src/Tests/SonarLint.UnitTest/TestCases/ReturnValueIgnored.cs
+++ b/src/Tests/SonarLint.UnitTest/TestCases/ReturnValueIgnored.cs
@@ -51,7 +51,16 @@ namespace Tests.Diagnostics
 
             PureType.GetValue(); // Noncompliant
             NonPureType.GetValue();
+
+            "".DoSomething(null); // Compliant
+            new int[] { 1 }.DoSomething(null); // Compliant
         }
         void M(object o) { }
+    }
+
+    public static class Ext
+    {
+        public static int DoSomething<T>(this IEnumerable<T> self, Action action) { return 42; }
+        public static int DoSomething(this string self, Action action) { return 42; }
     }
 }


### PR DESCRIPTION
Checked the Roslyn project, there are some cases of `ToArray` and `ToList` calls that force the loading of the `IEnumerable`.

Also, there's a `Single` call being reported. Single might have a side-effect, it can throw an exception.

I think we shouldn't filter out these cases.